### PR TITLE
feat: update formality

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6182,9 +6182,8 @@
       }
     },
     "formality-lang": {
-      "version": "0.3.133",
-      "resolved": "https://registry.npmjs.org/formality-lang/-/formality-lang-0.3.133.tgz",
-      "integrity": "sha512-YZYYwHiPuw8lsJaZtFJtVySnkGPzQwG0OTpL4kbA1gGqHwsFNhSi133mWN381TLjq0EtUI1bTVwSbAppa6rMZA==",
+      "version": "github:moonad/Formality#3e17a1830cc8662a4d546a2ec107351292cef398",
+      "from": "github:moonad/Formality#fix/variable-redeclaration",
       "requires": {
         "xhr-request-promise": "^0.1.2"
       }

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
   },
   "dependencies": {
     "anser": "^1.4.8",
-    "formality-lang": "^0.3.133",
+    "formality-lang": "github:moonad/Formality#fix/variable-redeclaration",
     "mobx": "^5.13.1",
     "mobx-preact": "^3.0.0",
     "preact": "^10.0.0-rc.3",

--- a/src/formality-lang.d.ts
+++ b/src/formality-lang.d.ts
@@ -4,6 +4,7 @@ declare module "formality-lang" {
   import net from "formality-lang/fm-net";
   import to_js from "formality-lang/fm-to-js";
   import to_net from "formality-lang/fm-to-net";
+  import forall from "formality-lang/forall";
 
   function exec(
     term_name: string,
@@ -12,7 +13,7 @@ declare module "formality-lang" {
     opts: any
   ): Term;
 
-  export { Defs, core, lang, net, to_net, to_js, exec };
+  export { Defs, core, lang, net, to_net, to_js, exec, forall };
 }
 
 declare module "formality-lang/fm-core" {
@@ -280,6 +281,8 @@ declare module "formality-lang/fm-lang" {
     erase
   } from "formality-lang/fm-core";
 
+  import { Loader } from "formality-lang/forall";
+
   interface Adt {
     adt_pram: [string, Term, boolean][];
     adt_indx: [string, Term, boolean][];
@@ -321,6 +324,7 @@ declare module "formality-lang/fm-lang" {
     file: string,
     code: string,
     tokenify: boolean,
+    loader?: Loader,
     root?: boolean,
     loaded?: { [key: string]: Parsed }
   ): Promise<Parsed>;
@@ -335,9 +339,6 @@ declare module "formality-lang/fm-lang" {
 
   function show(ast: Term): string;
   function gen_name(n: number): string;
-  function load_file(path: string): Promise<string>;
-  function load_file_parents(path: string): Promise<string[]>;
-  function save_file(name: string, code: string): Promise<string>;
 
   function derive_adt_type(file: string, adt: Adt): Term;
   function derive_adt_ctor(file: string, adt: Adt, c: number): Term;
@@ -391,10 +392,31 @@ declare module "formality-lang/fm-lang" {
     replace_refs,
     derive_adt_type,
     derive_adt_ctor,
-    save_file,
-    load_file,
-    load_file_parents,
     version
+  };
+}
+
+declare module "formality-lang/forall" {
+  function load_file_parents(path: string): Promise<string[]>;
+  function save_file(name: string, code: string): Promise<string>;
+
+  type Loader = (path: string) => Promise<string>;
+  const load_file: Loader;
+  const with_file_system_cache: (
+    loader: Loader,
+    cache_dir_path?: string
+  ) => Loader;
+  const with_local_files: (loader: Loader, local_dir_path?: string) => Loader;
+  const with_local_storage_cache: (loader: Loader, prefix?: string) => Loader;
+
+  export {
+    Loader,
+    load_file_parents,
+    load_file,
+    save_file,
+    with_file_system_cache,
+    with_local_files,
+    with_local_storage_cache
   };
 }
 

--- a/src/model.ts
+++ b/src/model.ts
@@ -38,8 +38,17 @@ export interface Module {
 }
 
 export class ModuleLoader {
+  private load_file: fm.forall.Loader = fm.forall.with_local_storage_cache(
+    fm.forall.load_file
+  );
+
   public async load_local(code: string): Promise<Module> {
-    const { defs, tokens } = await fm.lang.parse("local", code, true);
+    const { defs, tokens } = await fm.lang.parse(
+      "local",
+      code,
+      true,
+      this.load_file
+    );
 
     return {
       code,
@@ -70,7 +79,7 @@ export class ModuleLoader {
     code: string
   ): Promise<Either<string, string>> {
     try {
-      return right(await fm.lang.save_file(name, code));
+      return right(await fm.forall.save_file(name, code));
     } catch (e) {
       return left(e.toString());
     }
@@ -124,12 +133,17 @@ export class ModuleLoader {
   }
 
   private async load_code_from_path(path: string) {
-    const code = await fm.lang.load_file(path);
-    const { defs, tokens } = await fm.lang.parse(path, code, true);
+    const code = await this.load_file(path);
+    const { defs, tokens } = await fm.lang.parse(
+      path,
+      code,
+      true,
+      this.load_file
+    );
     return { code, defs, tokens };
   }
 
   private async load_parents(path: string) {
-    return await fm.lang.load_file_parents(path);
+    return await fm.forall.load_file_parents(path);
   }
 }


### PR DESCRIPTION
Given that @MaiaVictor is really busy, instead of waiting him to publish a new version of Formality with the fix I've made to the redeclaration, I just changed the dependency (for now) to point to the fix branch.

It's worth noting that Root@0 is broken on FPM due to a missing import (FPM doesnt parse or check the code, so there is room for those kind of stuff to happen), so I recomend going to `http://localhost:8080/Base@0` so it will load Base instead of Root.

Those kinds of issues won't happen in the new Forall Server that I'm working on right now, so that's not a big deal.